### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/vpc-flowlog-visualization/vpc-flowlogs-to-kibana.json
+++ b/vpc-flowlog-visualization/vpc-flowlogs-to-kibana.json
@@ -222,7 +222,7 @@
             }
           }
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Timeout": 20,
         "TracingConfig": {
           "Mode": "Active"


### PR DESCRIPTION
CloudFormation templates in aws-govcloud-continuous-monitoring have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.